### PR TITLE
Fix: genre 검색 구현

### DIFF
--- a/watchapedia/app/genre/repository.py
+++ b/watchapedia/app/genre/repository.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import select, or_, func
 from sqlalchemy.orm import Session
 from fastapi import Depends
 from watchapedia.database.connection import get_db_session
@@ -30,4 +30,16 @@ class GenreRepository():
     def get_genre_by_genre_name(self, name: str) -> Genre | None:
         get_genre_query = select(Genre).filter(Genre.name == name)
         return self.session.scalar(get_genre_query)
-        
+    
+    def get_genres_by_genre_name(self, name: str) -> list[Genre]:
+        get_genre_query = select(Genre).filter(
+            or_(
+                Genre.name.contains(name),
+                func.lower(name).like(func.concat("%", Genre.name, "%"))
+                #func.lower(name).like(f"%{Genre.name}%")
+            )
+        )
+        return self.session.scalars(get_genre_query).all()
+        #get_genre_query = select(Genre).filter(Genre.name.contains(name))
+        #return self.session.scalars(get_genre_query).all()
+

--- a/watchapedia/app/search/dto/responses.py
+++ b/watchapedia/app/search/dto/responses.py
@@ -1,12 +1,8 @@
 from pydantic import BaseModel
-# from watchapedia.app.movie.dto.responses import MovieDataResponse
-from watchapedia.app.user.dto.responses import UserResponse
 
 class SearchResponse(BaseModel):
-    # movie_list: list[MovieDataResponse]
-    #user_list: list[UserResponse]
     movie_list: list[int] | None
     user_list: list[int] | None
     participant_list: list[int] | None
     collection_list: list[int] | None
-
+    movie_dict_by_genre : dict[str, list[int]]

--- a/watchapedia/app/search/service.py
+++ b/watchapedia/app/search/service.py
@@ -5,37 +5,52 @@ from watchapedia.app.movie.service import MovieService
 from watchapedia.app.user.service import UserService
 from watchapedia.app.participant.service import ParticipantService
 from watchapedia.app.collection.service import CollectionService
+from watchapedia.app.genre.repository import GenreRepository
 
 class SearchService():
     def __init__(self,
             movie_service: Annotated[MovieService, Depends()],
             user_service: Annotated[UserService, Depends()],
             participant_service: Annotated[ParticipantService, Depends()],
-            collection_service: Annotated[CollectionService, Depends()]
+            collection_service: Annotated[CollectionService, Depends()],
+            genre_repository: Annotated[GenreRepository, Depends()]
             ) -> None:
         self.movie_service = movie_service
         self.user_service = user_service
         self.participant_service = participant_service
         self.collection_service = collection_service
+        self.genre_repository = genre_repository
+
     
     def search(self,
             name: str
             ) -> None:
-        self.movie_list = self.movie_service.search_movie_list(name)
+        self.movie_list = self.movie_service.search_movie_list(title=name)
         self.user_list = self.user_service.search_user_list(name)
         self.participant_list = self.participant_service.search_participant_list(name)
         self.collection_list = self.collection_service.search_collection_list(name)
+
+    def search_genre(self,
+            name: str
+            ) -> None:
+        self.genre_list = self.genre_repository.get_genres_by_genre_name(name)
+        self.movie_dict_by_genre = {}
+        for genre in self.genre_list:
+            self.movie_dict_by_genre[genre.name] = self.movie_service.search_movie_list(genres=[genre.name])
+        for key in self.movie_dict_by_genre:
+            self.movie_dict_by_genre[key] = [movie.id for movie in self.movie_dict_by_genre[key]]
 
     def process_search_response(self) -> SearchResponse:
         movie_list = [i.id for i in self.movie_list]
         user_list = [i.id for i in self.user_list]
         participant_list = [i.id for i in self.participant_list]
         collection_list = [i.id for i in self.collection_list]
-
+        
         return SearchResponse(
                 movie_list=movie_list,
                 user_list=user_list,
                 participant_list=participant_list,
-                collection_list=collection_list
+                collection_list=collection_list,
+                movie_dict_by_genre=self.movie_dict_by_genre
                 )
 

--- a/watchapedia/app/search/views.py
+++ b/watchapedia/app/search/views.py
@@ -13,5 +13,6 @@ def search(
         search_q: str = Depends(validate_search_query)
         ) -> SearchResponse:
     search_service.search(search_q)
+    search_service.search_genre(search_q)
     return search_service.process_search_response()
 


### PR DESCRIPTION
## 개요
검색 api에서 영화 장르 검색 기능을 추가했습니다.

검색 쿼리가 장르 이름을 포함하는 경우, 장르 이름이 검색 쿼리를 포함하는 경우 해당 장르를 가지는 영화의 id를 반환합니다.
예를 들어, (쿼리, 존재하는 장르명)이
- (코미, 코미디) -> 검색됨
- (호러코미디, 코미디) -> 검색됨
- (호러코미, 코미디) -> 코미디 장르는 검색 안됨. 호러 장르는 존재한다면 검색됨.

## PR 유형
어떤 변경 사항이 있나요?
- [O] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타 : 
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [O] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://udacity.github.io/git-styleguide/) 참고
- [O] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).